### PR TITLE
Specify static directory for storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "storybook": "start-storybook -p 6006"
+    "storybook": "start-storybook -s ./public -p 6006"
   },
   "dependencies": {
     "next": "9.4.4",


### PR DESCRIPTION
`yarn storybook` に -s オプションつけ忘れていた。